### PR TITLE
Bug fix in xml2stm.py

### DIFF
--- a/baseline/recipe/local/mgb_data_prep.sh
+++ b/baseline/recipe/local/mgb_data_prep.sh
@@ -40,7 +40,7 @@ cat dev.full | while read basename; do
 done
 
 #Creating a file reco2file_channel which is used by convert_ctm.pl in local/score.sh script
-rm -rf reco2file_channel
+rm -rf $dirtest/reco2file_channel
 cat $dirtest/wav.scp >> $dirtest/reco2file_channel
 for f in $dirtest/reco2file_channel; do
     sed -i "s/$/ 0/" $f;

--- a/baseline/recipe/local/xml2stm.py
+++ b/baseline/recipe/local/xml2stm.py
@@ -42,7 +42,7 @@ def loadXml(xmlFileName, opts):
     startTime = float(segment.attributes['starttime'].value)
     endTime = float(segment.attributes['endtime'].value)
 
-    tokens = [e.childNodes[0].data for e in segment.getElementsByTagName('element')]
+    tokens = [e.childNodes[0].data for e in segment.getElementsByTagName('element') if len(e.childNodes)]
     # skip any word starts with '#'
     tokens = filter(lambda i: not i.startswith('#'), tokens)
     # convert to buckwalter if required


### PR DESCRIPTION
Some manually transcribed words have no values. For example see word 1829
from file vim dev_xml_2016_02_17/bw/5331FFF2-358E-445E-BA71-74B745387304.xml
(line number 2114).
These will result in a python error due to indexing an empty childNodes list.
